### PR TITLE
feat: redesign portfolio with modern react experience

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,38 +1,45 @@
 :root {
   --font-sans: "Inter", "Space Grotesk", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
   --transition-base: 220ms ease;
-  --glow-1: rgba(87, 128, 255, 0.18);
-  --glow-2: rgba(144, 94, 255, 0.22);
+  --transition-slow: 640ms cubic-bezier(0.22, 1, 0.36, 1);
   --radius-xl: 32px;
   --radius-lg: 24px;
-  --radius-md: 16px;
+  --radius-md: 18px;
   --radius-sm: 12px;
+  --shadow-soft: 0 24px 80px -40px rgba(32, 60, 180, 0.6);
 }
 
 [data-theme="dark"] {
-  --color-bg: #050712;
-  --color-surface: rgba(16, 20, 44, 0.6);
-  --color-surface-strong: rgba(20, 24, 52, 0.85);
-  --color-glass-border: rgba(120, 144, 255, 0.16);
-  --color-text: rgba(236, 242, 255, 0.96);
-  --color-text-muted: rgba(188, 200, 240, 0.68);
-  --color-accent: #7c6cff;
-  --color-accent-2: #33c9ff;
-  --color-accent-soft: rgba(102, 132, 255, 0.28);
-  --shadow-elevated: 0 40px 100px -45px rgba(15, 39, 135, 0.9);
+  --color-bg: #01030e;
+  --color-surface: rgba(12, 16, 44, 0.75);
+  --color-surface-strong: rgba(18, 23, 62, 0.92);
+  --color-border: rgba(132, 144, 255, 0.16);
+  --color-border-strong: rgba(146, 158, 255, 0.35);
+  --color-text: rgba(236, 240, 255, 0.98);
+  --color-text-muted: rgba(178, 191, 242, 0.72);
+  --color-accent: #6c8bff;
+  --color-accent-2: #3fd8ff;
+  --color-highlight: rgba(110, 140, 255, 0.35);
+  --gradient-bg: radial-gradient(circle at 15% 10%, rgba(112, 135, 255, 0.28), transparent 60%),
+    radial-gradient(circle at 85% 30%, rgba(69, 224, 255, 0.22), transparent 55%),
+    radial-gradient(circle at 35% 85%, rgba(162, 112, 255, 0.18), transparent 55%);
 }
 
 [data-theme="light"] {
-  --color-bg: #f6f7ff;
+  --color-bg: #f7f8ff;
   --color-surface: rgba(255, 255, 255, 0.78);
   --color-surface-strong: rgba(255, 255, 255, 0.95);
-  --color-glass-border: rgba(82, 106, 204, 0.18);
-  --color-text: #0c1330;
-  --color-text-muted: rgba(32, 44, 88, 0.68);
-  --color-accent: #4b62ff;
-  --color-accent-2: #008dd5;
-  --color-accent-soft: rgba(75, 98, 255, 0.2);
-  --shadow-elevated: 0 40px 90px -55px rgba(29, 46, 92, 0.35);
+  --color-border: rgba(120, 140, 220, 0.18);
+  --color-border-strong: rgba(112, 128, 220, 0.3);
+  --color-text: #101633;
+  --color-text-muted: rgba(30, 42, 88, 0.72);
+  --color-accent: #4158ff;
+  --color-accent-2: #0c9ed6;
+  --color-highlight: rgba(65, 88, 255, 0.22);
+  --gradient-bg: radial-gradient(circle at 10% 20%, rgba(94, 112, 255, 0.18), transparent 58%),
+    radial-gradient(circle at 85% 18%, rgba(61, 210, 255, 0.22), transparent 48%),
+    radial-gradient(circle at 35% 82%, rgba(140, 118, 255, 0.16), transparent 55%);
 }
 
 * {
@@ -41,27 +48,24 @@
 
 html,
 body {
-  margin: 0;
-  padding: 0;
   width: 100%;
   height: 100%;
 }
 
 body {
+  margin: 0;
   font-family: var(--font-sans);
-  background: radial-gradient(circle at top left, rgba(120, 149, 255, 0.22), transparent 45%),
-    radial-gradient(circle at bottom right, rgba(120, 213, 255, 0.18), transparent 40%),
-    var(--color-bg);
+  background: var(--gradient-bg), var(--color-bg);
   color: var(--color-text);
   min-height: 100vh;
-  line-height: 1.65;
+  line-height: 1.7;
   position: relative;
   overflow-x: hidden;
 }
 
 img {
-  max-width: 100%;
   display: block;
+  max-width: 100%;
 }
 
 a {
@@ -71,25 +75,33 @@ a {
 
 .app-shell {
   position: relative;
-  z-index: 2;
+  z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 4rem;
+  min-height: 100vh;
+}
+
+.main {
+  width: min(1120px, calc(100% - 3rem));
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6rem;
+  padding: 6rem 0 5rem;
 }
 
 .header {
   position: sticky;
   top: 0;
-  z-index: 10;
-  padding: 1.5rem 0;
-  backdrop-filter: blur(16px);
-  background: linear-gradient(120deg, rgba(10, 12, 28, 0.75), rgba(10, 18, 38, 0.35));
-  border-bottom: 1px solid rgba(124, 140, 220, 0.2);
+  z-index: 30;
+  backdrop-filter: blur(20px);
+  background: linear-gradient(120deg, rgba(5, 9, 24, 0.88), rgba(7, 11, 28, 0.55));
+  border-bottom: 1px solid var(--color-border);
+  padding: 1.25rem 0;
 }
 
 [data-theme="light"] .header {
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.85), rgba(248, 249, 255, 0.7));
-  border-bottom: 1px solid rgba(148, 158, 230, 0.22);
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.88), rgba(247, 247, 255, 0.75));
 }
 
 .nav {
@@ -102,35 +114,42 @@ a {
 }
 
 .nav__brand {
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  font-size: 1.1rem;
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  font-size: 0.92rem;
   text-transform: uppercase;
-  padding: 0.6rem 1rem;
+  padding: 0.55rem 1rem;
   border-radius: 999px;
-  background: linear-gradient(120deg, rgba(124, 108, 255, 0.26), rgba(51, 201, 255, 0.18));
-  border: 1px solid rgba(132, 148, 255, 0.45);
-  box-shadow: 0 20px 45px -35px rgba(88, 114, 255, 0.8);
+  border: 1px solid var(--color-border-strong);
+  background: linear-gradient(135deg, rgba(124, 146, 255, 0.32), rgba(57, 215, 255, 0.22));
+  box-shadow: 0 18px 36px -24px rgba(68, 115, 255, 0.8);
+  transition: transform var(--transition-base);
+}
+
+.nav__brand:hover {
+  transform: translateY(-1px);
 }
 
 .nav__links {
   display: flex;
-  gap: 1rem;
   align-items: center;
+  gap: 1rem;
 }
 
 .nav__link {
-  font-weight: 500;
-  padding: 0.5rem 0.9rem;
+  padding: 0.45rem 0.85rem;
   border-radius: 999px;
-  transition: all var(--transition-base);
+  font-weight: 500;
   color: var(--color-text-muted);
+  transition: background var(--transition-base), color var(--transition-base), transform var(--transition-base);
 }
 
 .nav__link:hover,
 .nav__link:focus {
-  background: var(--color-accent-soft);
+  background: var(--color-highlight);
   color: var(--color-text);
+  transform: translateY(-1px);
 }
 
 .theme-toggle {
@@ -140,22 +159,22 @@ a {
   height: 32px;
   border-radius: 999px;
   cursor: pointer;
-  background: linear-gradient(135deg, rgba(120, 106, 255, 0.35), rgba(61, 206, 255, 0.35));
-  border: 1px solid rgba(124, 138, 255, 0.45);
+  background: linear-gradient(120deg, rgba(110, 134, 255, 0.38), rgba(56, 212, 255, 0.28));
+  border: 1px solid var(--color-border-strong);
   display: grid;
   place-items: center;
   overflow: hidden;
   transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
-.theme-toggle:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 4px;
+.theme-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px -24px rgba(72, 116, 255, 0.9);
 }
 
-.theme-toggle:hover {
-  box-shadow: 0 12px 32px -20px rgba(60, 122, 255, 0.85);
-  transform: translateY(-1px);
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
 }
 
 .theme-toggle__track {
@@ -175,12 +194,8 @@ a {
   bottom: 4px;
   width: 50%;
   border-radius: 999px;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.25));
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.35));
   transition: transform 420ms ease;
-  transform: translateX(0%);
-}
-
-.theme-toggle--dark .theme-toggle__beam {
   transform: translateX(0%);
 }
 
@@ -189,692 +204,704 @@ a {
 }
 
 .theme-toggle__icon {
-  width: 1.2rem;
-  height: 1.2rem;
+  width: 1.15rem;
+  height: 1.15rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   color: var(--color-text);
-  transition: opacity 320ms ease, transform 320ms ease;
+  opacity: 0.85;
 }
 
-.theme-toggle--dark .theme-toggle__icon--sun,
-.theme-toggle--light .theme-toggle__icon--moon {
-  opacity: 1;
-  transform: scale(1);
-}
-
-.theme-toggle--dark .theme-toggle__icon--moon,
-.theme-toggle--light .theme-toggle__icon--sun {
-  opacity: 0.3;
-  transform: scale(0.85);
-}
-
-main {
-  width: min(1120px, calc(100% - 3rem));
-  margin: 0 auto;
+.section {
   display: flex;
   flex-direction: column;
-  gap: 6rem;
+  gap: 2.5rem;
+}
+
+.section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 720px;
+}
+
+.section__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.section__header h2 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  line-height: 1.2;
+  font-size: clamp(1.75rem, 1.2rem + 1vw, 2.25rem);
+  margin: 0;
+}
+
+.section__header p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.section__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.75rem;
 }
 
 .hero {
-  position: relative;
-  padding-top: 6rem;
-  display: flex;
-  flex-direction: column;
-  gap: 3rem;
-}
-
-.hero__inner {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 3rem;
-  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2.5rem;
 }
 
-@media (max-width: 900px) {
-  .hero__inner {
-    grid-template-columns: 1fr;
-  }
+.hero__content {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: clamp(2rem, 1rem + 2vw, 3rem);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
 }
 
-.hero__intro {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+.hero__content::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at var(--pointer-x, 50%) var(--pointer-y, 50%), rgba(108, 136, 255, 0.2), transparent 60%);
+  opacity: 0.6;
+  pointer-events: none;
 }
 
 .hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.hero__title {
+  font-family: var(--font-display);
+  font-size: clamp(2.75rem, 2rem + 2vw, 3.6rem);
+  margin: 0;
+  line-height: 1.05;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.hero__subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 1.05rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.hero__resume {
+  border-radius: 999px;
+  padding: 0.75rem 1.4rem;
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-text);
+  font-weight: 500;
+  transition: background var(--transition-base), transform var(--transition-base);
+}
+
+.hero__resume:hover {
+  background: var(--color-highlight);
+  transform: translateY(-1px);
+}
+
+.hero__contact {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.hero__contact-link {
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  transition: transform var(--transition-base), border-color var(--transition-base);
+}
+
+.hero__contact-link:hover {
+  transform: translateX(4px);
+  border-color: var(--color-border-strong);
+}
+
+.hero__contact-link span {
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.hero__contact-link strong {
+  font-size: 1.05rem;
+}
+
+.hero__card {
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-xl);
+  padding: clamp(2rem, 1rem + 2vw, 3rem);
+  border: 1px solid var(--color-border-strong);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero__stats {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hero__stat-value {
+  font-size: 2.1rem;
+  font-weight: 600;
+}
+
+.hero__stat-label {
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.hero__quote {
+  margin: 0;
+  font-style: italic;
+  color: var(--color-text-muted);
+}
+
+.text-animate {
+  display: inline-flex;
+  position: relative;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.text-animate__word {
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity var(--transition-slow), transform var(--transition-slow);
+  background: linear-gradient(120deg, var(--color-accent), var(--color-accent-2));
+  -webkit-background-clip: text;
+  color: transparent;
+  font-weight: 600;
+}
+
+.text-animate__word.is-active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.blur-fade {
+  opacity: 0;
+  transform: translateY(32px) scale(0.98);
+  filter: blur(20px);
+  transition: opacity var(--transition-slow), transform var(--transition-slow), filter var(--transition-slow);
+}
+
+.blur-fade.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  filter: blur(0px);
+}
+
+.interactive-hover-button {
+  position: relative;
+  border-radius: 999px;
+  padding: 0.9rem 1.8rem;
+  font-weight: 600;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #060b1d;
+  background: linear-gradient(120deg, #7bfffa, #7c8dff);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.interactive-hover-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 44px -24px rgba(124, 143, 255, 0.9);
+}
+
+.interactive-hover-button__content {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.interactive-hover-button__glow {
+  position: absolute;
+  inset: -40%;
+  background: radial-gradient(circle at var(--pointer-x, 50%) var(--pointer-y, 50%), rgba(255, 255, 255, 0.6), transparent 60%);
+  opacity: 0;
+  transition: opacity 320ms ease;
+}
+
+.interactive-hover-button:hover .interactive-hover-button__glow {
+  opacity: 1;
+}
+
+.magic-card {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+  transform-style: preserve-3d;
+  will-change: transform;
+  transition: transform 180ms ease;
+}
+
+.magic-card:hover {
+  transform: translateY(-4px) scale(1.01);
+}
+
+.magic-card__beam {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at var(--pointer-x, 50%) var(--pointer-y, 50%), rgba(108, 136, 255, 0.35), transparent 60%);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.magic-card__content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.magic-card__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.26em;
+  color: var(--color-text-muted);
+}
+
+.magic-card__title {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.magic-card__description {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.magic-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.magic-card__tag {
+  font-size: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(124, 142, 255, 0.18);
+  border: 1px solid rgba(124, 142, 255, 0.28);
+}
+
+.animated-beam {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  padding: clamp(2rem, 1.4rem + 2vw, 3.2rem);
+  overflow: hidden;
+  display: grid;
+  gap: 1.8rem;
+}
+
+.animated-beam__line {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(108, 136, 255, 0.12), rgba(63, 216, 255, 0.08));
+  animation: beam-flow 6s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes beam-flow {
+  0% {
+    transform: translateX(-25%);
+    opacity: 0.3;
+  }
+  50% {
+    transform: translateX(0%);
+    opacity: 0.55;
+  }
+  100% {
+    transform: translateX(25%);
+    opacity: 0.3;
+  }
+}
+
+.animated-beam__card {
+  position: relative;
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-lg);
+  padding: 1.6rem;
+  border: 1px solid var(--color-border-strong);
+  box-shadow: 0 24px 60px -45px rgba(60, 90, 220, 0.55);
+}
+
+.animated-beam__index {
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+}
+
+.animated-beam__card h3 {
+  margin: 0.6rem 0 0.75rem;
+  font-size: 1.35rem;
+}
+
+.animated-beam__card p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.animated-beam__card ul {
+  margin: 1.1rem 0 0.9rem;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.65rem;
+  color: var(--color-text-muted);
+}
+
+.animated-beam__card li::marker {
+  color: var(--color-accent);
+}
+
+.animated-beam__meta {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.skills__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
+.circular-progress {
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem 1.25rem 1.4rem;
+  display: grid;
+  place-items: center;
+  gap: 0.85rem;
+}
+
+.circular-progress__svg {
+  width: 120px;
+  height: 120px;
+  transform: rotate(-90deg);
+}
+
+.circular-progress__track {
+  fill: none;
+  stroke: rgba(140, 156, 255, 0.18);
+  stroke-width: 8;
+}
+
+.circular-progress__indicator {
+  fill: none;
+  stroke: var(--color-accent);
+  stroke-width: 8;
+  stroke-linecap: round;
+  transform-origin: center;
+  transition: stroke-dashoffset 720ms cubic-bezier(0.22, 1, 0.36, 1);
+  filter: drop-shadow(0 6px 22px rgba(108, 136, 255, 0.45));
+}
+
+.circular-progress__value {
+  position: absolute;
+  display: flex;
+  align-items: baseline;
+  gap: 0.15rem;
+  font-weight: 600;
+  font-size: 1.6rem;
+}
+
+.circular-progress__value small {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.circular-progress__label {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.skills__marquee {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.marquee {
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.marquee__inner {
+  display: flex;
+  gap: 2.5rem;
+  padding: 0.85rem 1.5rem;
+  width: fit-content;
+  animation: marquee-left 22s linear infinite;
+}
+
+.marquee--right .marquee__inner {
+  animation: marquee-right 22s linear infinite;
+}
+
+.marquee__item {
+  font-size: 0.85rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+@keyframes marquee-left {
+  0% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes marquee-right {
+  0% {
+    transform: translateX(-50%);
+  }
+  100% {
+    transform: translateX(0%);
+  }
+}
+
+.education {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  padding: clamp(2rem, 1.2rem + 2vw, 3rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.education__list {
+  display: grid;
+  gap: 1rem;
+}
+
+.education__item {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  background: rgba(124, 141, 255, 0.08);
+  border-radius: var(--radius-md);
+  padding: 1.25rem 1.5rem;
+  border: 1px solid transparent;
+  transition: border-color var(--transition-base), transform var(--transition-base);
+}
+
+.education__item:hover {
+  border-color: var(--color-border-strong);
+  transform: translateX(6px);
+}
+
+.education__year {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.education__item h3 {
+  margin: 0 0 0.25rem;
+}
+
+.education__item p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.contact {
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border-strong);
+  padding: clamp(2rem, 1.4rem + 2vw, 3.2rem);
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.contact__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.contact__item {
+  background: rgba(124, 142, 255, 0.08);
+  border: 1px solid rgba(124, 142, 255, 0.22);
+  border-radius: var(--radius-md);
+  padding: 1.1rem 1.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.contact__item a {
+  word-break: break-word;
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.contact__label {
   font-size: 0.85rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
 
-.hero__title {
-  font-size: clamp(2.6rem, 4vw, 3.5rem);
-  line-height: 1.1;
-  margin: 0;
-  font-weight: 700;
-}
-
-.hero__description {
-  color: var(--color-text-muted);
-  margin: 0;
-  max-width: 42ch;
-}
-
-.hero__actions {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.hero__social {
-  display: flex;
-  gap: 1rem;
-}
-
-.hero__social a {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  display: grid;
-  place-items: center;
-  border: 1px solid rgba(132, 148, 255, 0.4);
-  background: rgba(60, 92, 255, 0.08);
-  color: var(--color-text);
-  transition: transform var(--transition-base), box-shadow var(--transition-base);
-}
-
-.hero__social a:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 20px 40px -30px rgba(90, 124, 255, 0.9);
-}
-
-.hero__visual {
-  display: flex;
-  justify-content: center;
-}
-
-.hero-card {
-  padding: 1.5rem;
-  gap: 1.25rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.hero-card__portrait {
-  width: 260px;
-  height: 260px;
-  object-fit: cover;
-  border-radius: var(--radius-xl);
-  border: 1px solid var(--color-glass-border);
-  box-shadow: var(--shadow-elevated);
-}
-
-.hero-card__badge {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  width: 100%;
-}
-
-.hero-card__pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 1rem;
-  border-radius: 999px;
-  background: rgba(124, 108, 255, 0.1);
-  border: 1px solid rgba(124, 108, 255, 0.3);
-  font-size: 0.85rem;
-  color: var(--color-text);
-}
-
-.hero__marquees {
-  display: grid;
-  gap: 0.6rem;
-}
-
-.marquee {
-  overflow: hidden;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(120, 140, 255, 0.22);
-  background: linear-gradient(120deg, rgba(124, 108, 255, 0.1), rgba(51, 201, 255, 0.1));
-}
-
-.marquee__track {
-  display: flex;
-  gap: 1.5rem;
-  animation: marquee 25s linear infinite;
-  padding: 0.8rem 0;
-}
-
-.marquee__track--reverse {
-  animation-direction: reverse;
-}
-
-.marquee__item {
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
-}
-
-@keyframes marquee {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
-  }
-}
-
-.section-heading {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  max-width: 60ch;
-}
-
-.section-heading h2 {
-  font-size: clamp(1.8rem, 3vw, 2.6rem);
-  margin: 0;
-}
-
-.section-heading p {
-  margin: 0;
-  color: var(--color-text-muted);
-}
-
-.spotlight__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
-}
-
-.magic-card {
-  position: relative;
-  background: var(--color-surface);
-  border: 1px solid var(--color-glass-border);
-  border-radius: var(--radius-lg);
-  padding: 1.75rem;
-  overflow: hidden;
-  transform: rotateX(var(--tilt-x, 0deg)) rotateY(var(--tilt-y, 0deg));
-  transition: transform 260ms ease, border-color 260ms ease, background 260ms ease;
-  backdrop-filter: blur(18px);
-  box-shadow: 0 24px 50px -40px rgba(47, 72, 255, 0.65);
-}
-
-.magic-card__glow {
-  position: absolute;
-  inset: -40%;
-  background: radial-gradient(circle at var(--pointer-x, 50%) var(--pointer-y, 50%), rgba(124, 108, 255, 0.35), transparent 55%);
-  opacity: 0;
-  transition: opacity 280ms ease;
-}
-
-.magic-card:hover .magic-card__glow {
-  opacity: 1;
-}
-
-.magic-card h3 {
-  margin-top: 0;
-  margin-bottom: 0.6rem;
-  font-size: 1.2rem;
-}
-
-.magic-card p {
-  margin: 0;
-  color: var(--color-text-muted);
-}
-
-.circular-progress {
-  margin-top: 1.5rem;
-  position: relative;
-  width: 160px;
-  height: 160px;
-}
-
-.circular-progress svg {
-  width: 100%;
-  height: 100%;
-}
-
-.circular-progress__bg {
-  fill: none;
-  stroke: rgba(132, 148, 255, 0.2);
-  stroke-width: 12;
-}
-
-.circular-progress__indicator {
-  fill: none;
-  stroke-width: 12;
-  stroke-linecap: round;
-  transform: rotate(-90deg);
-  transform-origin: 50% 50%;
-  stroke: var(--color-accent);
-  transition: stroke-dashoffset 720ms ease;
-}
-
-.circular-progress__content {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.25rem;
-}
-
-.circular-progress__value {
-  font-size: 2rem;
-  font-weight: 700;
-}
-
-.circular-progress__label {
-  color: var(--color-text-muted);
-  font-size: 0.85rem;
-}
-
-.experience__timeline,
-.projects__grid,
-.skills__grid,
-.education__list,
-.contact__links {
-  display: grid;
-  gap: 1.5rem;
-}
-
-.experience__timeline {
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.experience__item ul {
-  list-style: none;
-  padding: 0;
-  margin: 1rem 0 0;
-  display: grid;
-  gap: 0.6rem;
-  color: var(--color-text-muted);
-}
-
-.experience__meta {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  color: var(--color-text-muted);
-  font-size: 0.9rem;
-}
-
-.projects__grid {
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.project-card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.6rem;
-}
-
-.project-card__link {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  display: grid;
-  place-items: center;
-  border: 1px solid rgba(124, 108, 255, 0.4);
-  transition: background var(--transition-base), transform var(--transition-base);
-}
-
-.project-card__link:hover {
-  background: var(--color-accent-soft);
-  transform: scale(1.05);
-}
-
-.project-card__tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 1rem;
-}
-
-.project-card__tags span {
-  padding: 0.4rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(51, 201, 255, 0.14);
-  border: 1px solid rgba(51, 201, 255, 0.25);
-  font-size: 0.75rem;
-  letter-spacing: 0.04em;
-}
-
-.skills__grid {
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.skills__chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 1rem;
-}
-
-.skills__chips span {
-  padding: 0.45rem 0.85rem;
-  border-radius: 999px;
-  border: 1px solid rgba(124, 108, 255, 0.35);
-  background: rgba(124, 108, 255, 0.12);
-  font-size: 0.85rem;
-}
-
-.education__list {
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.education__item header {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  color: var(--color-text-muted);
-}
-
-.education__program {
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.contact__grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 300px);
-  gap: 1.5rem;
-}
-
-@media (max-width: 960px) {
-  .contact__grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.contact__form {
-  display: grid;
-  gap: 1rem;
-}
-
-.contact__form label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
-}
-
-.contact__form input,
-.contact__form textarea {
-  border-radius: var(--radius-sm);
-  border: 1px solid rgba(124, 108, 255, 0.35);
-  padding: 0.9rem 1rem;
-  background: rgba(12, 18, 40, 0.35);
-  color: var(--color-text);
-  font: inherit;
-  transition: border var(--transition-base), background var(--transition-base);
-}
-
-[data-theme="light"] .contact__form input,
-[data-theme="light"] .contact__form textarea {
-  background: rgba(255, 255, 255, 0.85);
-}
-
-.contact__form input:focus,
-.contact__form textarea:focus {
-  outline: none;
-  border-color: rgba(51, 201, 255, 0.6);
-  background: rgba(51, 201, 255, 0.1);
-}
-
-.contact__submit {
-  margin-top: 0.5rem;
-  padding: 0.9rem 1.1rem;
-  border-radius: 999px;
-  border: none;
-  cursor: pointer;
-  display: inline-flex;
-  gap: 0.6rem;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  background: linear-gradient(120deg, #7c6cff, #33c9ff);
-  color: white;
-  transition: transform var(--transition-base), box-shadow var(--transition-base);
-}
-
-.contact__submit:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 20px 40px -28px rgba(84, 118, 255, 0.9);
-}
-
-.contact__links {
-  grid-template-columns: 1fr;
-}
-
-.contact__link a {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-  font-weight: 600;
-}
-
 .footer {
-  padding: 2rem 0 4rem;
+  margin-top: auto;
+  padding: 3rem 0 2.5rem;
+}
+
+.footer__content {
+  width: min(1120px, calc(100% - 3rem));
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
   text-align: center;
   color: var(--color-text-muted);
-  font-size: 0.85rem;
 }
 
-.interactive-button {
-  position: relative;
-  overflow: hidden;
-  border-radius: 999px;
-  padding: 0.85rem 1.6rem;
-  background: linear-gradient(120deg, rgba(124, 108, 255, 0.45), rgba(51, 201, 255, 0.45));
-  color: var(--color-text);
-  border: 1px solid rgba(124, 108, 255, 0.4);
-  font-weight: 600;
-  transition: transform var(--transition-base), box-shadow var(--transition-base);
-}
-
-.interactive-button__shine {
-  position: absolute;
-  inset: -120% 40% 20% -40%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.55), transparent);
-  transform: rotate(12deg) translateX(-120%);
-  animation: button-shine 3.5s ease-in-out infinite;
-}
-
-.interactive-button:hover {
-  transform: translateY(-2px) scale(1.01);
-  box-shadow: 0 22px 44px -35px rgba(82, 110, 255, 0.9);
-}
-
-@keyframes button-shine {
-  0% {
-    transform: rotate(12deg) translateX(-120%);
-  }
-  50% {
-    transform: rotate(12deg) translateX(110%);
-  }
-  100% {
-    transform: rotate(12deg) translateX(120%);
-  }
-}
-
-.animated-text {
-  display: inline-flex;
+.footer__links {
+  display: flex;
+  gap: 1.25rem;
   flex-wrap: wrap;
-  gap: 0.35rem;
 }
 
-.animated-text__word {
-  display: inline-block;
-  transform: translateY(16px);
-  opacity: 0;
-  animation: text-rise 640ms ease forwards;
-}
-
-@keyframes text-rise {
-  from {
-    transform: translateY(16px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
-.blur-fade {
-  opacity: 0;
-  transform: translateY(24px);
-  filter: blur(16px);
-  transition: opacity 720ms ease, transform 720ms ease, filter 720ms ease;
-}
-
-.blur-fade.is-visible {
-  opacity: 1;
-  transform: translateY(0);
-  filter: blur(0);
+.footer__links a {
+  color: var(--color-text);
+  font-weight: 500;
 }
 
 .particle-canvas {
   position: fixed;
   inset: 0;
+  width: 100vw;
+  height: 100vh;
   z-index: 0;
+  pointer-events: none;
 }
 
 .pointer {
   position: fixed;
-  width: 14px;
-  height: 14px;
+  top: 0;
+  left: 0;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
-  background: var(--color-accent);
-  mix-blend-mode: screen;
-  pointer-events: none;
-  z-index: 20;
+  background: radial-gradient(circle, rgba(124, 142, 255, 0.7), rgba(124, 142, 255, 0));
   transform: translate(-50%, -50%);
+  mix-blend-mode: lighten;
+  pointer-events: none;
   opacity: 0;
-  transition: opacity 320ms ease;
+  transition: opacity 380ms ease;
+  z-index: 40;
 }
 
 .pointer--trail {
-  width: 180px;
-  height: 180px;
-  background: radial-gradient(circle, rgba(124, 108, 255, 0.35), transparent 60%);
-  filter: blur(45px);
-  opacity: 0;
+  width: 48px;
+  height: 48px;
+  background: radial-gradient(circle, rgba(124, 142, 255, 0.25), rgba(124, 142, 255, 0));
+  filter: blur(12px);
 }
 
 .pointer--visible {
   opacity: 1;
 }
 
-.animated-beam {
-  position: absolute;
-  inset: 10% auto auto -12%;
-  width: 45%;
-  height: 280px;
-  display: grid;
-  transform: rotate(-8deg);
-  pointer-events: none;
-  z-index: -1;
-}
-
-.animated-beam__line {
-  width: 100%;
-  height: 8px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, transparent, rgba(51, 201, 255, 0.55), transparent);
-  animation: beam-wave 6s ease-in-out infinite;
-  filter: blur(1px);
-}
-
-.animated-beam__line--two {
-  height: 5px;
-  opacity: 0.7;
-  animation-delay: 1.2s;
-}
-
-.animated-beam__line--three {
-  height: 3px;
-  opacity: 0.45;
-  animation-delay: 2.4s;
-}
-
-@keyframes beam-wave {
-  0%,
-  100% {
-    transform: translateX(-10%);
+@media (max-width: 860px) {
+  .main {
+    padding-top: 4.5rem;
   }
-  50% {
-    transform: translateX(12%);
+
+  .nav__links {
+    gap: 0.65rem;
+  }
+
+  .nav__link {
+    padding: 0.35rem 0.65rem;
+  }
+
+  .hero__contact {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
 }
 
 @media (max-width: 640px) {
-  body {
-    background: linear-gradient(180deg, rgba(124, 108, 255, 0.12), transparent 40%), var(--color-bg);
+  .header {
+    position: static;
+  }
+
+  .main {
+    width: calc(100% - 2.5rem);
+    padding-top: 3.5rem;
   }
 
   .nav {
-    flex-direction: column;
-    align-items: flex-start;
+    width: calc(100% - 2.5rem);
+    flex-wrap: wrap;
+    justify-content: center;
   }
 
   .nav__links {
     flex-wrap: wrap;
+    justify-content: center;
   }
 
-  main {
-    width: min(640px, calc(100% - 2rem));
-    gap: 4rem;
+  .hero__content,
+  .hero__card {
+    padding: 1.75rem;
   }
-
-  .header {
-    padding: 1.1rem 0;
-  }
-
-  .hero__actions {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .hero-card__portrait {
-    width: 220px;
-    height: 220px;
-  }
-}
-
-[data-theme="light"] .magic-card {
-  background: var(--color-surface);
-  box-shadow: 0 32px 50px -45px rgba(65, 86, 180, 0.35);
-}
-
-[data-theme="light"] .hero-card__pill {
-  background: rgba(75, 98, 255, 0.12);
-}
-
-[data-theme="light"] .project-card__tags span {
-  background: rgba(51, 201, 255, 0.18);
-}
-
-[data-theme="light"] .interactive-button {
-  background: linear-gradient(120deg, rgba(124, 108, 255, 0.55), rgba(51, 201, 255, 0.55));
-  color: #0d1335;
-}
-
-[data-theme="light"] .pointer {
-  mix-blend-mode: multiply;
 }

--- a/assets/js/app.jsx
+++ b/assets/js/app.jsx
@@ -34,8 +34,10 @@ const ThemeProvider = ({ children }) => {
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 };
 
+const useTheme = () => useContext(ThemeContext);
+
 const AnimatedThemeToggle = () => {
-  const { theme, toggle } = useContext(ThemeContext);
+  const { theme, toggle } = useTheme();
   return (
     <button
       className={`theme-toggle theme-toggle--${theme}`}
@@ -60,6 +62,215 @@ const AnimatedThemeToggle = () => {
   );
 };
 
+const usePrefersReducedMotion = () => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(query.matches);
+    const listener = (event) => setPrefersReducedMotion(event.matches);
+    query.addEventListener("change", listener);
+    return () => query.removeEventListener("change", listener);
+  }, []);
+
+  return prefersReducedMotion;
+};
+
+const BlurFade = ({ as: Component = "div", delay = 0, children, className = "", ...props }) => {
+  const ref = useRef(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      ref.current?.classList.add("is-visible");
+      return;
+    }
+
+    const element = ref.current;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("is-visible");
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.2 }
+    );
+
+    if (element) observer.observe(element);
+    return () => observer.disconnect();
+  }, [prefersReducedMotion]);
+
+  return (
+    <Component ref={ref} className={`blur-fade ${className}`} style={{ transitionDelay: `${delay}ms` }} {...props}>
+      {children}
+    </Component>
+  );
+};
+
+const TextAnimate = ({ words }) => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((prev) => (prev + 1) % words.length);
+    }, 2600);
+    return () => clearInterval(id);
+  }, [words.length]);
+
+  return (
+    <span className="text-animate" aria-live="polite">
+      {words.map((word, idx) => (
+        <span key={word} className={`text-animate__word ${idx === index ? "is-active" : ""}`}>
+          {word}
+        </span>
+      ))}
+    </span>
+  );
+};
+
+const InteractiveHoverButton = ({ href, children }) => {
+  const buttonRef = useRef(null);
+
+  useEffect(() => {
+    const node = buttonRef.current;
+    if (!node) return;
+
+    const handlePointer = (event) => {
+      const rect = node.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+      node.style.setProperty("--pointer-x", `${x}px`);
+      node.style.setProperty("--pointer-y", `${y}px`);
+    };
+
+    node.addEventListener("pointermove", handlePointer);
+    return () => node.removeEventListener("pointermove", handlePointer);
+  }, []);
+
+  return (
+    <a className="interactive-hover-button" href={href} target="_blank" rel="noreferrer" ref={buttonRef}>
+      <span className="interactive-hover-button__glow" aria-hidden="true" />
+      <span className="interactive-hover-button__content">{children}</span>
+    </a>
+  );
+};
+
+const MagicCard = ({ title, subtitle, description, tags, link }) => {
+  const cardRef = useRef(null);
+
+  useEffect(() => {
+    const card = cardRef.current;
+    if (!card) return;
+
+    const handlePointer = (event) => {
+      const rect = card.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+      const centerX = rect.width / 2;
+      const centerY = rect.height / 2;
+      const rotateX = ((y - centerY) / centerY) * -6;
+      const rotateY = ((x - centerX) / centerX) * 6;
+      card.style.setProperty("--pointer-x", `${x}px`);
+      card.style.setProperty("--pointer-y", `${y}px`);
+      card.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+    };
+
+    const reset = () => {
+      card.style.transform = "rotateX(0deg) rotateY(0deg)";
+    };
+
+    card.addEventListener("pointermove", handlePointer);
+    card.addEventListener("pointerleave", reset);
+
+    return () => {
+      card.removeEventListener("pointermove", handlePointer);
+      card.removeEventListener("pointerleave", reset);
+    };
+  }, []);
+
+  return (
+    <a className="magic-card" href={link} target="_blank" rel="noreferrer" ref={cardRef}>
+      <div className="magic-card__beam" aria-hidden="true" />
+      <div className="magic-card__content">
+        <span className="magic-card__eyebrow">{subtitle}</span>
+        <h3 className="magic-card__title">{title}</h3>
+        <p className="magic-card__description">{description}</p>
+        <div className="magic-card__tags">
+          {tags.map((tag) => (
+            <span key={tag} className="magic-card__tag">
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </a>
+  );
+};
+
+const Marquee = ({ items, direction = "left" }) => (
+  <div className={`marquee marquee--${direction}`} aria-hidden="true">
+    <div className="marquee__inner">
+      {[...items, ...items].map((item, index) => (
+        <span key={`${item}-${index}`} className="marquee__item">
+          {item}
+        </span>
+      ))}
+    </div>
+  </div>
+);
+
+const AnimatedCircularProgress = ({ label, value }) => {
+  const normalizedValue = Math.min(Math.max(value, 0), 100);
+  const radius = 54;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (normalizedValue / 100) * circumference;
+
+  return (
+    <div className="circular-progress" role="img" aria-label={`${label} proficiency ${normalizedValue}%`}>
+      <svg className="circular-progress__svg" viewBox="0 0 120 120">
+        <circle className="circular-progress__track" cx="60" cy="60" r={radius} />
+        <circle
+          className="circular-progress__indicator"
+          cx="60"
+          cy="60"
+          r={radius}
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+        />
+      </svg>
+      <div className="circular-progress__value">
+        <span>{normalizedValue}</span>
+        <small>%</small>
+      </div>
+      <p className="circular-progress__label">{label}</p>
+    </div>
+  );
+};
+
+const AnimatedBeam = ({ items }) => {
+  return (
+    <div className="animated-beam">
+      <div className="animated-beam__line" aria-hidden="true" />
+      {items.map((item, index) => (
+        <div key={item.title} className="animated-beam__card">
+          <span className="animated-beam__index">0{index + 1}</span>
+          <h3>{item.title}</h3>
+          <p>{item.summary}</p>
+          <ul>
+            {item.points.map((point) => (
+              <li key={point}>{point}</li>
+            ))}
+          </ul>
+          <span className="animated-beam__meta">{item.meta}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
 const ParticlesBackground = () => {
   const canvasRef = useRef(null);
   const particlesRef = useRef([]);
@@ -68,27 +279,24 @@ const ParticlesBackground = () => {
   useEffect(() => {
     const canvas = canvasRef.current;
     const context = canvas.getContext("2d");
-    let frameId;
 
     const resize = () => {
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
-      particlesRef.current = Array.from({ length: Math.min(160, Math.floor(canvas.width / 12)) }, () => ({
+      particlesRef.current = Array.from({ length: Math.min(200, Math.floor(canvas.width / 8)) }, () => ({
         x: Math.random() * canvas.width,
         y: Math.random() * canvas.height,
-        vx: (Math.random() - 0.5) * 0.3,
-        vy: (Math.random() - 0.5) * 0.3,
-        radius: Math.random() * 1.5 + 0.5,
-        alpha: Math.random() * 0.5 + 0.1,
+        vx: (Math.random() - 0.5) * 0.25,
+        vy: (Math.random() - 0.5) * 0.25,
+        radius: Math.random() * 1.4 + 0.4,
+        alpha: Math.random() * 0.5 + 0.15,
       }));
     };
 
     const render = () => {
       const theme = document.documentElement.getAttribute("data-theme") || "dark";
-      const hue = theme === "dark" ? 215 : 230;
+      const hue = theme === "dark" ? 218 : 228;
       context.clearRect(0, 0, canvas.width, canvas.height);
-      context.fillStyle = "transparent";
-      context.fillRect(0, 0, canvas.width, canvas.height);
 
       particlesRef.current.forEach((particle) => {
         particle.x += particle.vx;
@@ -98,23 +306,21 @@ const ParticlesBackground = () => {
         if (particle.y < 0 || particle.y > canvas.height) particle.vy *= -1;
 
         context.beginPath();
-        context.fillStyle = `hsla(${hue}, 80%, 70%, ${particle.alpha})`;
+        context.fillStyle = `hsla(${hue}, 78%, 68%, ${particle.alpha})`;
         context.arc(particle.x, particle.y, particle.radius, 0, Math.PI * 2);
         context.fill();
       });
 
-      frameId = requestAnimationFrame(render);
+      animationRef.current = requestAnimationFrame(render);
     };
 
     resize();
     render();
 
     window.addEventListener("resize", resize);
-    animationRef.current = frameId;
-
     return () => {
-      cancelAnimationFrame(animationRef.current);
       window.removeEventListener("resize", resize);
+      cancelAnimationFrame(animationRef.current);
     };
   }, []);
 
@@ -134,10 +340,8 @@ const PointerGlow = () => {
 
     const handlePointerMove = (event) => {
       target.current = { x: event.clientX, y: event.clientY };
-      if (!pointer.classList.contains("pointer--visible")) {
-        pointer.classList.add("pointer--visible");
-        trail.classList.add("pointer--visible");
-      }
+      pointer.classList.add("pointer--visible");
+      trail.classList.add("pointer--visible");
     };
 
     const handleLeave = () => {
@@ -146,11 +350,15 @@ const PointerGlow = () => {
     };
 
     const update = () => {
-      position.current.x += (target.current.x - position.current.x) * 0.12;
-      position.current.y += (target.current.y - position.current.y) * 0.12;
+      position.current.x += (target.current.x - position.current.x) * 0.14;
+      position.current.y += (target.current.y - position.current.y) * 0.14;
 
       pointer.style.transform = `translate(${target.current.x}px, ${target.current.y}px)`;
       trail.style.transform = `translate(${position.current.x}px, ${position.current.y}px)`;
+
+      const root = document.documentElement;
+      root.style.setProperty("--pointer-x", `${target.current.x}px`);
+      root.style.setProperty("--pointer-y", `${target.current.y}px`);
 
       rafRef.current = requestAnimationFrame(update);
     };
@@ -174,409 +382,195 @@ const PointerGlow = () => {
   );
 };
 
-const AnimatedText = ({ text }) => {
-  const segments = text.split(" ");
-  return (
-    <span className="animated-text" aria-label={text}>
-      {segments.map((segment, index) => (
-        <span
-          key={`${segment}-${index}`}
-          className="animated-text__word"
-          style={{ animationDelay: `${index * 0.08}s` }}
-        >
-          {segment}
-        </span>
-      ))}
-    </span>
-  );
-};
-
-const BlurFade = ({ children, className = "" }) => {
-  const ref = useRef(null);
-
-  useEffect(() => {
-    const node = ref.current;
-    if (!node) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add("is-visible");
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.2 }
-    );
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, []);
-
-  return (
-    <div ref={ref} className={`blur-fade ${className}`}>
-      {children}
-    </div>
-  );
-};
-
-const HoverButton = ({ href, children }) => (
-  <a href={href} className="interactive-button" target={href?.startsWith("http") ? "_blank" : undefined} rel={href?.startsWith("http") ? "noreferrer" : undefined}>
-    <span className="interactive-button__shine" aria-hidden="true" />
-    <span className="interactive-button__inner">{children}</span>
-  </a>
-);
-
-const MagicCard = ({ children, className = "" }) => {
-  const ref = useRef(null);
-
-  useEffect(() => {
-    const node = ref.current;
-    if (!node) return;
-
-    const handlePointerMove = (event) => {
-      const rect = node.getBoundingClientRect();
-      const x = event.clientX - rect.left;
-      const y = event.clientY - rect.top;
-      const centerX = rect.width / 2;
-      const centerY = rect.height / 2;
-      const rotateX = ((y - centerY) / centerY) * -7;
-      const rotateY = ((x - centerX) / centerX) * 7;
-
-      node.style.setProperty("--tilt-x", `${rotateX}deg`);
-      node.style.setProperty("--tilt-y", `${rotateY}deg`);
-      node.style.setProperty("--pointer-x", `${x}px`);
-      node.style.setProperty("--pointer-y", `${y}px`);
-    };
-
-    const resetTilt = () => {
-      node.style.setProperty("--tilt-x", "0deg");
-      node.style.setProperty("--tilt-y", "0deg");
-    };
-
-    node.addEventListener("pointermove", handlePointerMove);
-    node.addEventListener("pointerleave", resetTilt);
-
-    return () => {
-      node.removeEventListener("pointermove", handlePointerMove);
-      node.removeEventListener("pointerleave", resetTilt);
-    };
-  }, []);
-
-  return (
-    <article ref={ref} className={`magic-card ${className}`}>
-      <span className="magic-card__glow" aria-hidden="true" />
-      {children}
-    </article>
-  );
-};
-
-const Marquee = ({ items, reverse = false }) => (
-  <div className="marquee" aria-hidden="true">
-    <div className={`marquee__track ${reverse ? "marquee__track--reverse" : ""}`}>
-      {items.map((item, index) => (
-        <span key={`${item}-${index}`} className="marquee__item">
-          {item}
-        </span>
-      ))}
-      {items.map((item, index) => (
-        <span key={`${item}-dup-${index}`} className="marquee__item">
-          {item}
-        </span>
-      ))}
-    </div>
-  </div>
-);
-
-const CircularProgress = ({ value, label }) => {
-  const radius = 54;
-  const circumference = 2 * Math.PI * radius;
-  const clampedValue = Math.min(100, Math.max(0, value));
-  const offset = circumference - (clampedValue / 100) * circumference;
-
-  return (
-    <div className="circular-progress" role="img" aria-label={`${value} percent ${label}`}>
-      <svg viewBox="0 0 120 120">
-        <circle className="circular-progress__bg" cx="60" cy="60" r={radius} />
-        <circle
-          className="circular-progress__indicator"
-          cx="60"
-          cy="60"
-          r={radius}
-          strokeDasharray={circumference}
-          strokeDashoffset={offset}
-        />
-      </svg>
-      <div className="circular-progress__content">
-        <span className="circular-progress__value">{value}%</span>
-        <span className="circular-progress__label">{label}</span>
-      </div>
-    </div>
-  );
-};
-
-const AnimatedBeam = () => (
-  <div className="animated-beam" aria-hidden="true">
-    <span className="animated-beam__line animated-beam__line--one" />
-    <span className="animated-beam__line animated-beam__line--two" />
-    <span className="animated-beam__line animated-beam__line--three" />
-  </div>
-);
-
-const NavBar = () => (
-  <nav className="nav">
-    <a className="nav__brand" href="#home" aria-label="Saurabh Rajput home">
-      Sau24k
-    </a>
-    <div className="nav__links">
-      {[
-        { href: "#experience", label: "Experience" },
-        { href: "#projects", label: "Projects" },
-        { href: "#skills", label: "Skills" },
-        { href: "#education", label: "Education" },
-        { href: "#contact", label: "Contact" },
-      ].map((item) => (
-        <a key={item.href} className="nav__link" href={item.href}>
-          {item.label}
-        </a>
-      ))}
-    </div>
-    <AnimatedThemeToggle />
-  </nav>
-);
-
-const stats = [
-  {
-    title: "Systems Reliability",
-    description: "Predictive maintenance orchestration for healthy fleets.",
-    value: 92,
-  },
-  {
-    title: "AI Adoption Velocity",
-    description: "Accelerated GTM for mobility AI services across cities.",
-    value: 88,
-  },
-  {
-    title: "Experiment Success",
-    description: "Research experiments converted to production impact.",
-    value: 80,
-  },
+const contactLinks = [
+  { label: "Email", value: "saurabhrajput24k@gmail.com", href: "mailto:saurabhrajput24k@gmail.com" },
+  { label: "Phone", value: "+1 (312) 404-1275", href: "tel:+13124041275" },
+  { label: "LinkedIn", value: "linkedin.com/in/saurabhrajput24k", href: "https://www.linkedin.com/in/saurabhrajput24k" },
+  { label: "GitHub", value: "github.com/Saurabh24k", href: "https://github.com/Saurabh24k" },
+  { label: "Portfolio", value: "saurabh24k.github.io", href: "https://saurabh24k.github.io" },
+  { label: "IIT Chicago", value: "srajput2@hawk.iit.edu", href: "mailto:srajput2@hawk.iit.edu" },
 ];
 
 const experiences = [
   {
-    role: "AI Engineer",
-    company: "Transurban",
-    period: "2023 — Present",
-    highlights: [
-      "Architected anomaly detection for tolling network stability",
-      "Led experimentation platform surfacing predictive safety insights",
-      "Scaled model lifecycle automation across hybrid cloud"
+    title: "AI Engineer · TechClub Inc.",
+    meta: "Feb 2025 - Jul 2025 · Remote",
+    summary: "Enterprise GenAI systems that deliver measurable support impact.",
+    points: [
+      "Built a production RAG assistant with FastAPI, LangChain, ChromaDB, SentenceTransformers; resolution time ↓35%.",
+      "Shipped semantic search on SageMaker using FAISS + OpenAI embeddings; escalations ↓30% and relevance ↑42% (Ragas, human eval).",
+      "Stood up guardrails (PII redaction, tool-call idempotency) and continuous evals keeping hallucinations <20%.",
+      "Productionized on AWS (ECS, SageMaker) with Docker, CI/CD, OpenTelemetry observability.",
     ],
   },
   {
-    role: "Research Assistant",
-    company: "IIT Chicago",
-    period: "2021 — 2023",
-    highlights: [
-      "Published computer vision framework for smart parking",
-      "Designed reinforcement agents for adaptive traffic signals",
-      "Mentored cross-functional innovation sprints"
+    title: "AI Engineer · Parkiez Mobility",
+    meta: "Dec 2020 - Mar 2022 · Pune, India",
+    summary: "Computer vision and MLOps for intelligent mobility infrastructure.",
+    points: [
+      "Boosted parking-spot detection accuracy 25% with TensorFlow/OpenCV YOLO pipeline deployed to AWS edge.",
+      "Launched availability prediction on SageMaker reducing driver search time 15% and improving lot utilization.",
+      "Optimized data processing infra on AWS (EC2, S3, CloudWatch) and automated Dockerized releases via Jenkins & CodePipeline.",
     ],
   },
 ];
 
 const projects = [
   {
-    name: "Mobility Guardian",
-    description: "Edge AI toolkit that fuses cameras, lidar, and telemetry to prevent roadway hazards in real time.",
-    tags: ["Edge AI", "Vision", "Safety"],
+    title: "Inbound Carrier Sales Agent",
+    subtitle: "Voice AI Agent · FastAPI · LangChain",
+    description:
+      "Multi-turn voice agent verifying FMCSA MC numbers, negotiating loads, and logging real-time insights across policy-compliant flows.",
     link: "https://github.com/Saurabh24k",
+    tags: ["LiveKit", "OpenAI", "SQLModel", "Docker"],
   },
   {
-    name: "GlassCity Digital Twin",
-    description: "Immersive city simulation bridging generative AI with infrastructure planning dashboards.",
-    tags: ["Digital Twin", "Generative AI", "Strategy"],
+    title: "Cache Augmented Generation (CAG-LLM)",
+    subtitle: "LLM Infra · Streamlit · Hugging Face",
+    description:
+      "Latency-aware LLM caching layer with telemetry, response grading, and an immersive interface to benchmark retrieval strategies.",
     link: "https://github.com/Saurabh24k",
+    tags: ["Caching", "Prompt Engineering", "Observability"],
   },
   {
-    name: "Signal Pulse",
-    description: "Autonomous traffic controller optimizing congestion with reinforcement learning agents.",
-    tags: ["Reinforcement Learning", "Mobility", "Optimization"],
+    title: "Autonomous AI Screening Agent",
+    subtitle: "Agentic Workflow · FastAPI · pgvector",
+    description:
+      "Modular sub-agents orchestrated to parse resumes, run screenings, score fit, and trigger scheduling with vector logging throughout.",
     link: "https://github.com/Saurabh24k",
+    tags: ["LangChain", "PostgreSQL", "Voice"],
   },
 ];
 
 const skills = [
-  {
-    title: "AI Platforms",
-    items: ["Azure ML", "AWS SageMaker", "Databricks", "Vertex AI"],
-  },
-  {
-    title: "Modeling",
-    items: ["Vision Transformers", "Graph Networks", "Generative AI", "Reinforcement Learning"],
-  },
-  {
-    title: "Product Craft",
-    items: ["MLOps", "Design Systems", "Experimentation", "Ethical AI"],
-  },
+  { label: "GenAI & RAG", value: 94 },
+  { label: "LLM Ops", value: 92 },
+  { label: "Computer Vision", value: 88 },
+  { label: "MLOps", value: 90 },
+  { label: "Cloud & DevOps", value: 86 },
 ];
 
 const education = [
   {
     school: "Illinois Institute of Technology",
-    program: "MS — Computer Science",
-    period: "2021 — 2023",
-    details: "Focused on AI systems, robotics, and human-centered computing.",
+    degree: "M.S. Artificial Intelligence",
+    year: "Dec 2024",
   },
   {
-    school: "Rajasthan Technical University",
-    program: "BTech — Computer Science",
-    period: "2017 — 2021",
-    details: "Graduated with honors researching mobility intelligence.",
+    school: "Jayawantrao Sawant College of Engineering",
+    degree: "B.E. Computer Engineering",
+    year: "Jun 2021",
   },
 ];
 
-const contactLinks = [
-  { icon: "uil-linkedin", label: "LinkedIn", href: "https://www.linkedin.com/in/saurabh-rajput-24k/" },
-  { icon: "uil-github", label: "GitHub", href: "https://github.com/Saurabh24k" },
-  { icon: "uil-envelope", label: "Email", href: "mailto:srajput2@hawk.iit.edu" },
-];
+const setLocalPointerVars = (event) => {
+  const target = event.currentTarget;
+  const rect = target.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+  target.style.setProperty("--pointer-x", `${x}px`);
+  target.style.setProperty("--pointer-y", `${y}px`);
+};
+
+const resetLocalPointerVars = (event) => {
+  const target = event.currentTarget;
+  target.style.removeProperty("--pointer-x");
+  target.style.removeProperty("--pointer-y");
+};
 
 const Hero = () => (
-  <section id="home" className="hero">
-    <AnimatedBeam />
-    <div className="hero__inner">
-      <div className="hero__intro">
-        <BlurFade className="hero__eyebrow">
-          <span>Artificial Intelligence Engineer</span>
-        </BlurFade>
-        <BlurFade>
-          <h1 className="hero__title">
-            <AnimatedText text="Designing responsive intelligence that elevates mobility, safety, and human experiences." />
-          </h1>
-        </BlurFade>
-        <BlurFade>
-          <p className="hero__description">
-            I’m Saurabh Rajput, architecting human-centered AI ecosystems that bridge research breakthroughs with resilient, delightful products.
-          </p>
-        </BlurFade>
-        <BlurFade className="hero__actions">
-          <HoverButton href="#contact">Let’s build together</HoverButton>
-          <HoverButton href="assets/pdf/Saurabh Rajput.pdf">Download résumé</HoverButton>
-        </BlurFade>
-        <BlurFade className="hero__social">
-          {contactLinks.map((link) => (
-            <a key={link.label} href={link.href} aria-label={link.label} target="_blank" rel="noreferrer">
-              <i className={`uil ${link.icon}`} aria-hidden="true" />
-            </a>
-          ))}
-        </BlurFade>
+  <section className="section hero" id="hero">
+    <BlurFade className="hero__content" delay={100} onPointerMove={setLocalPointerVars} onPointerLeave={resetLocalPointerVars}>
+      <span className="hero__eyebrow">Saurabh Rajput · AI Engineer</span>
+      <h1 className="hero__title">
+        Architecting
+        <TextAnimate
+          words={[" Retrieval-Augmented AI", " Voice-first Agents", " Trustworthy ML Platforms", " Intelligent Mobility"]}
+        />
+      </h1>
+      <p className="hero__subtitle">
+        I build resilient AI platforms that close the loop between data, models, and business outcomes—grounded in GenAI,
+        MLOps, and intelligent automation across mobility, logistics, and enterprise support.
+      </p>
+      <div className="hero__actions">
+        <InteractiveHoverButton href="mailto:saurabhrajput24k@gmail.com">
+          Start a Conversation
+        </InteractiveHoverButton>
+        <a className="hero__resume" href="assets/pdf/Saurabh_Rajput_(Resume).pdf" target="_blank" rel="noreferrer">
+          Download Résumé
+        </a>
       </div>
-      <BlurFade className="hero__visual">
-        <MagicCard className="hero-card">
-          <img src="assets/img/perfil.png" alt="Portrait of Saurabh Rajput" className="hero-card__portrait" />
-          <div className="hero-card__badge">
-            <span className="hero-card__pill">
-              <i className="uil uil-robot" aria-hidden="true" /> MLOps • Vision • NLP
-            </span>
-            <span className="hero-card__pill">
-              <i className="uil uil-sparkle" aria-hidden="true" /> Responsible AI Advocate
-            </span>
-          </div>
-        </MagicCard>
-      </BlurFade>
-    </div>
-    <div className="hero__marquees">
-      <Marquee items={["Autonomous Mobility", "Vision Systems", "Edge AI", "Cloud MLOps", "Product Strategy", "Inclusive Design", "Experimentation", "Responsible AI"]} />
-      <Marquee items={["Urban Innovation", "Predictive Maintenance", "Digital Twins", "Human-Centered AI", "Safety Intelligence", "Data Storytelling"]} reverse />
-    </div>
-  </section>
-);
-
-const Spotlight = () => (
-  <section className="spotlight" aria-label="Impact metrics">
-    <div className="section-heading">
-      <BlurFade>
-        <h2>Impact in motion</h2>
-      </BlurFade>
-      <BlurFade>
-        <p>Experiment velocity, system reliability, and adoption rates across mission-critical platforms.</p>
-      </BlurFade>
-    </div>
-    <div className="spotlight__grid">
-      {stats.map((stat) => (
-        <BlurFade key={stat.title}>
-          <MagicCard>
-            <h3>{stat.title}</h3>
-            <p>{stat.description}</p>
-            <CircularProgress value={stat.value} label="Performance" />
-          </MagicCard>
-        </BlurFade>
-      ))}
-    </div>
+      <div className="hero__contact">
+        {contactLinks.slice(0, 3).map((item) => (
+          <a key={item.label} href={item.href} className="hero__contact-link">
+            <span>{item.label}</span>
+            <strong>{item.value}</strong>
+          </a>
+        ))}
+      </div>
+    </BlurFade>
+    <BlurFade
+      className="hero__card"
+      delay={250}
+      onPointerMove={setLocalPointerVars}
+      onPointerLeave={resetLocalPointerVars}
+    >
+      <div className="hero__stats">
+        <div>
+          <span className="hero__stat-value">5+</span>
+          <span className="hero__stat-label">Years shipping AI products</span>
+        </div>
+        <div>
+          <span className="hero__stat-value">28%</span>
+          <span className="hero__stat-label">CSAT lift via AI assistants</span>
+        </div>
+        <div>
+          <span className="hero__stat-value">30%</span>
+          <span className="hero__stat-label">Faster go-lives with reliable MLOps</span>
+        </div>
+      </div>
+      <p className="hero__quote">
+        “My craft combines GenAI experimentation with enterprise reliability—pairing Retrieval-Augmented Generation,
+        observability, and guardrails to earn user trust.”
+      </p>
+    </BlurFade>
   </section>
 );
 
 const Experience = () => (
-  <section id="experience" className="experience">
-    <div className="section-heading">
-      <BlurFade>
-        <h2>Experience</h2>
-      </BlurFade>
-      <BlurFade>
-        <p>Partnering with mobility operators and research labs to launch adaptive intelligence.</p>
-      </BlurFade>
-    </div>
-    <div className="experience__timeline">
-      {experiences.map((exp) => (
-        <BlurFade key={exp.role} className="experience__item">
-          <MagicCard>
-            <header>
-              <h3>{exp.role}</h3>
-              <div className="experience__meta">
-                <span>{exp.company}</span>
-                <span>{exp.period}</span>
-              </div>
-            </header>
-            <ul>
-              {exp.highlights.map((highlight) => (
-                <li key={highlight}>{highlight}</li>
-              ))}
-            </ul>
-          </MagicCard>
-        </BlurFade>
-      ))}
-    </div>
+  <section className="section" id="experience">
+    <BlurFade delay={100}>
+      <header className="section__header">
+        <span className="section__eyebrow">Experience</span>
+        <h2>Driving measurable outcomes across GenAI and computer vision.</h2>
+        <p>
+          Every engagement blends modern AI stacks with hardened delivery—linking experimentation to telemetry, MLOps, and
+          production uptime.
+        </p>
+      </header>
+    </BlurFade>
+    <BlurFade delay={200}>
+      <AnimatedBeam items={experiences} />
+    </BlurFade>
   </section>
 );
 
 const Projects = () => (
-  <section id="projects" className="projects">
-    <div className="section-heading">
-      <BlurFade>
-        <h2>Selected work</h2>
-      </BlurFade>
-      <BlurFade>
-        <p>Magnetizing new possibilities across urban infrastructure, safety, and autonomy.</p>
-      </BlurFade>
-    </div>
-    <div className="projects__grid">
-      {projects.map((project) => (
-        <BlurFade key={project.name}>
-          <MagicCard className="project-card">
-            <div className="project-card__header">
-              <h3>{project.name}</h3>
-              <a href={project.link} target="_blank" rel="noreferrer" className="project-card__link" aria-label={`View ${project.name}`}>
-                <i className="uil uil-external-link-alt" aria-hidden="true" />
-              </a>
-            </div>
-            <p>{project.description}</p>
-            <div className="project-card__tags">
-              {project.tags.map((tag) => (
-                <span key={tag}>{tag}</span>
-              ))}
-            </div>
-          </MagicCard>
+  <section className="section" id="projects">
+    <BlurFade delay={100}>
+      <header className="section__header">
+        <span className="section__eyebrow">Projects</span>
+        <h2>Agentic systems that orchestrate data, models, and automation.</h2>
+        <p>
+          I enjoy crafting opinionated workflows—voice agents, retrieval loops, and scoring engines—that ship to production with
+          observability baked in.
+        </p>
+      </header>
+    </BlurFade>
+    <div className="section__grid">
+      {projects.map((project, index) => (
+        <BlurFade key={project.title} delay={160 * (index + 1)}>
+          <MagicCard {...project} />
         </BlurFade>
       ))}
     </div>
@@ -584,130 +578,137 @@ const Projects = () => (
 );
 
 const Skills = () => (
-  <section id="skills" className="skills">
-    <div className="section-heading">
-      <BlurFade>
-        <h2>Capabilities</h2>
-      </BlurFade>
-      <BlurFade>
-        <p>Full-stack intelligence design from research to reliable operations.</p>
-      </BlurFade>
-    </div>
+  <section className="section" id="skills">
+    <BlurFade delay={100}>
+      <header className="section__header">
+        <span className="section__eyebrow">Capabilities</span>
+        <h2>Full-stack AI delivery across GenAI, MLOps, and applied ML.</h2>
+      </header>
+    </BlurFade>
     <div className="skills__grid">
-      {skills.map((skill) => (
-        <BlurFade key={skill.title}>
-          <MagicCard>
-            <h3>{skill.title}</h3>
-            <div className="skills__chips">
-              {skill.items.map((item) => (
-                <span key={item}>{item}</span>
-              ))}
+      {skills.map((skill, index) => (
+        <BlurFade key={skill.label} delay={150 * (index + 1)}>
+          <AnimatedCircularProgress {...skill} />
+        </BlurFade>
+      ))}
+    </div>
+    <div className="skills__marquee">
+      <Marquee
+        items={["FastAPI", "LangChain", "LlamaIndex", "TensorFlow", "PyTorch", "FAISS", "ChromaDB", "AWS SageMaker", "Docker", "Terraform", "Kafka", "OpenTelemetry"]}
+      />
+      <Marquee
+        direction="right"
+        items={["Redis", "pgvector", "Streamlit", "LiveKit", "CI/CD", "Airflow", "MLflow", "Weights & Biases", "Spark", "Ragas", "Guardrails", "Kubernetes"]}
+      />
+    </div>
+  </section>
+);
+
+const EducationContact = () => (
+  <section className="section" id="education">
+    <div className="education">
+      <BlurFade delay={100}>
+        <header className="section__header">
+          <span className="section__eyebrow">Education</span>
+          <h2>Academic foundation in artificial intelligence and computer engineering.</h2>
+        </header>
+      </BlurFade>
+      <div className="education__list">
+        {education.map((item, index) => (
+          <BlurFade key={item.school} delay={150 * (index + 1)} className="education__item">
+            <span className="education__year">{item.year}</span>
+            <div>
+              <h3>{item.degree}</h3>
+              <p>{item.school}</p>
             </div>
-          </MagicCard>
-        </BlurFade>
-      ))}
-    </div>
-  </section>
-);
-
-const Education = () => (
-  <section id="education" className="education">
-    <div className="section-heading">
-      <BlurFade>
-        <h2>Education</h2>
-      </BlurFade>
-      <BlurFade>
-        <p>Blending rigorous computer science foundations with applied urban tech innovation.</p>
-      </BlurFade>
-    </div>
-    <div className="education__list">
-      {education.map((item) => (
-        <BlurFade key={item.school} className="education__item">
-          <MagicCard>
-            <header>
-              <h3>{item.school}</h3>
-              <span>{item.period}</span>
-            </header>
-            <p className="education__program">{item.program}</p>
-            <p>{item.details}</p>
-          </MagicCard>
-        </BlurFade>
-      ))}
-    </div>
-  </section>
-);
-
-const Contact = () => (
-  <section id="contact" className="contact">
-    <div className="section-heading">
-      <BlurFade>
-        <h2>Let’s collaborate</h2>
-      </BlurFade>
-      <BlurFade>
-        <p>Share a challenge. I’ll respond with ideas, prototypes, or experiments ready to explore.</p>
-      </BlurFade>
-    </div>
-    <BlurFade className="contact__grid">
-      <MagicCard className="contact__card">
-        <form className="contact__form" action="https://formspree.io/f/xrgwbkog" method="POST">
-          <label>
-            <span>Name</span>
-            <input type="text" name="name" required placeholder="How should I greet you?" />
-          </label>
-          <label>
-            <span>Email</span>
-            <input type="email" name="email" required placeholder="Where can I reply?" />
-          </label>
-          <label>
-            <span>Project vision</span>
-            <textarea name="message" rows="4" required placeholder="Tell me about the future we’ll build." />
-          </label>
-          <button type="submit" className="contact__submit">
-            <span>Send message</span>
-            <i className="uil uil-message" aria-hidden="true" />
-          </button>
-        </form>
-      </MagicCard>
-      <div className="contact__links">
-        {contactLinks.map((link) => (
-          <MagicCard key={link.label} className="contact__link">
-            <a href={link.href} target="_blank" rel="noreferrer">
-              <i className={`uil ${link.icon}`} aria-hidden="true" />
-              <span>{link.label}</span>
-            </a>
-          </MagicCard>
+          </BlurFade>
         ))}
       </div>
-    </BlurFade>
+    </div>
+    <div className="contact" id="contact">
+      <BlurFade delay={100}>
+        <header className="section__header">
+          <span className="section__eyebrow">Let’s Collaborate</span>
+          <h2>Always open to building intelligent experiences that move the needle.</h2>
+          <p>Pick your channel—email, voice, or socials—and let’s architect the next AI story together.</p>
+        </header>
+      </BlurFade>
+      <div className="contact__grid">
+        {contactLinks.map((item, index) => (
+          <BlurFade key={item.label} delay={120 * (index + 1)} className="contact__item">
+            <span className="contact__label">{item.label}</span>
+            <a href={item.href}>{item.value}</a>
+          </BlurFade>
+        ))}
+      </div>
+    </div>
   </section>
+);
+
+const Header = () => (
+  <header className="header">
+    <nav className="nav">
+      <a className="nav__brand" href="#hero">
+        SR · AI ENGINEER
+      </a>
+      <div className="nav__links">
+        <a className="nav__link" href="#experience">
+          Experience
+        </a>
+        <a className="nav__link" href="#projects">
+          Projects
+        </a>
+        <a className="nav__link" href="#skills">
+          Skills
+        </a>
+        <a className="nav__link" href="#education">
+          Education
+        </a>
+        <a className="nav__link" href="#contact">
+          Contact
+        </a>
+        <AnimatedThemeToggle />
+      </div>
+    </nav>
+  </header>
 );
 
 const Footer = () => (
   <footer className="footer">
-    <p>© {new Date().getFullYear()} Saurabh Rajput. Engineered with curiosity & care.</p>
+    <div className="footer__content">
+      <p>© {new Date().getFullYear()} Saurabh Rajput. Crafted with React, animations, and a relentless focus on clarity.</p>
+      <div className="footer__links">
+        <a href="mailto:saurabhrajput24k@gmail.com">Email</a>
+        <a href="https://github.com/Saurabh24k" target="_blank" rel="noreferrer">
+          GitHub
+        </a>
+        <a href="https://www.linkedin.com/in/saurabhrajput24k" target="_blank" rel="noreferrer">
+          LinkedIn
+        </a>
+        <a href="assets/pdf/Saurabh_Rajput_(Resume).pdf" target="_blank" rel="noreferrer">
+          Résumé
+        </a>
+      </div>
+    </div>
   </footer>
 );
 
-const App = () => (
+const AppShell = () => (
   <ThemeProvider>
-    <ParticlesBackground />
     <PointerGlow />
+    <ParticlesBackground />
     <div className="app-shell">
-      <header className="header">
-        <NavBar />
-      </header>
-      <main>
+      <Header />
+      <main className="main">
         <Hero />
-        <Spotlight />
         <Experience />
         <Projects />
         <Skills />
-        <Education />
-        <Contact />
+        <EducationContact />
       </main>
       <Footer />
     </div>
   </ThemeProvider>
 );
 
-ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+ReactDOM.createRoot(document.getElementById("root")).render(<AppShell />);


### PR DESCRIPTION
## Summary
- rebuild the portfolio into a modern React single-page layout with animated hero, experience beam, projects grid, skills gauges, and contact blocks
- implement interactive UI primitives including blur-fade reveals, animated text, marquee, pointer glow, particles, and theme toggle with refined dark/light styling
- add reusable components for magic cards, hover buttons, circular progress, and data-driven content sourced from updated professional details

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ccb8aa7f04832fb161de510a94d749